### PR TITLE
Add ability to rename teams

### DIFF
--- a/data/-api-v1-project-list.coffee
+++ b/data/-api-v1-project-list.coffee
@@ -1,1 +1,1 @@
-angular.module('MM_Graph').run ($httpBackend)-> $httpBackend.whenGET('/api/v1/project/list').respond ["bsimm","samm"]
+angular.module('MM_Graph').run ($httpBackend)-> $httpBackend.whenGET('/api/v1/project/list').respond ["bsimm","ASVS","samm"]

--- a/src/controllers/team/Team-Admin-Controller.coffee
+++ b/src/controllers/team/Team-Admin-Controller.coffee
@@ -1,19 +1,29 @@
 angular.module('MM_Graph')
-  .controller 'TeamAdminController', ($scope,  API, team_Data)->
+  .controller 'TeamAdminController', ($scope, $location,  API, team_Data)->
 
 #    $scope.project = $routeParams.project  || team_Data.project  # todo: should only be using Team_Data here
 #    $scope.team    = $routeParams.team     || team_Data.team
-    $scope.status  = ""
+    $scope.deleteStatus  = ""
+    $scope.renameStatus  = ""
 
     $scope.delete_Team = ->
-      $scope.status = "deleting team"
+      $scope.deleteStatus = "deleting team"
       API.team_Delete team_Data.project, team_Data.team, (response)->
-        $scope.status = response
+        $scope.deleteStatus = response
+
+    $scope.rename_Team = (newTeamName) ->
+      API.team_Rename $scope.project, $scope.team, newTeamName, (response)->
+        if response
+          $scope.renameStatus = 'Team renamed, redirecting...'
+          $location.path($location.path().replace(team_Data.team, newTeamName))
+        else
+          $scope.renameStatus = 'Team rename failed. Check that team name is not already in use.'
 
     team_Data.load_Data ->
       #$scope.project = team_Data.project
       #$scope.team    = team_Data.team
       $scope.delete_Button_Message = "Delete team #{team_Data.team}"
+      $scope.rename_Button_Message = "Rename team #{team_Data.team}"
 
 #    using Team_Data, ->
 #      @.subscribe $scope, =>                  # register to receive notification when data is available

--- a/src/services/API.coffee
+++ b/src/services/API.coffee
@@ -22,20 +22,21 @@ class API
               callback? null, error?.data, error?.status
 
   # GET requests
-  data_Radar_Fields      : (project,       callback)=> @._GET "#{@.version}/data/#{project}/radar/fields"      , callback
-  data_Radar_Team        : (project, team, callback)=> @._GET "#{@.version}/data/#{project}/#{team}/radar"     , callback
-  data_Score             : (project, team, callback)=> @._GET "#{@.version}/data/#{project}/#{team}/score"     , callback
-  project_Activities     : (project,       callback)=> @._GET "#{@.version}/project/activities/#{project}"     , callback
-  project_Get            : (project,       callback)=> @._GET "#{@.version}/project/get/#{project}"            , callback
-  project_List           : (               callback)=> @._GET "#{@.version}/project/list"                      , callback
-  project_Schema         : (project,       callback)=> @._GET "#{@.version}/project/schema/#{project}"         , callback
-  project_Schema_Details : (project,       callback)=> @._GET "#{@.version}/project/schema-details/#{project}" , callback
-  project_Scores         : (project,       callback)=> @._GET "#{@.version}/project/scores/#{project}"         , callback
-  routes                 : (               callback)=> @._GET "#{@.version}/routes"                            , callback
-  team_Delete            : (project, team, callback)=> @._GET "#{@.version}/team/#{project}/delete/#{team}"    , callback
-  team_Get               : (project, team, callback)=> @._GET "#{@.version}/team/#{project}/get/#{team}"       , callback
-  team_New               : (project,       callback)=> @._GET "#{@.version}/team/#{project}/new"               , callback
-  teams_Proofs           : (project,       callback)=> @._GET "#{@.version}/teams/proofs/#{project}"           , callback
+  data_Radar_Fields      : (project,             callback)=> @._GET "#{@.version}/data/#{project}/radar/fields"            , callback
+  data_Radar_Team        : (project, team,       callback)=> @._GET "#{@.version}/data/#{project}/#{team}/radar"           , callback
+  data_Score             : (project, team,       callback)=> @._GET "#{@.version}/data/#{project}/#{team}/score"           , callback
+  project_Activities     : (project,             callback)=> @._GET "#{@.version}/project/activities/#{project}"           , callback
+  project_Get            : (project,             callback)=> @._GET "#{@.version}/project/get/#{project}"                  , callback
+  project_List           : (                     callback)=> @._GET "#{@.version}/project/list"                            , callback
+  project_Schema         : (project,             callback)=> @._GET "#{@.version}/project/schema/#{project}"               , callback
+  project_Schema_Details : (project,             callback)=> @._GET "#{@.version}/project/schema-details/#{project}"       , callback
+  project_Scores         : (project,             callback)=> @._GET "#{@.version}/project/scores/#{project}"               , callback
+  routes                 : (                     callback)=> @._GET "#{@.version}/routes"                                  , callback
+  team_Delete            : (project, team,       callback)=> @._GET "#{@.version}/team/#{project}/delete/#{team}"          , callback
+  team_Rename            : (project, team, name, callback)=> @._GET "#{@.version}/team/#{project}/rename/#{team}/#{name}"  , callback
+  team_Get               : (project, team,       callback)=> @._GET "#{@.version}/team/#{project}/get/#{team}"             , callback
+  team_New               : (project,             callback)=> @._GET "#{@.version}/team/#{project}/new"                     , callback
+  teams_Proofs           : (project,             callback)=> @._GET "#{@.version}/teams/proofs/#{project}"                 , callback
 
   # POST requests
   file_Save              : (project,team, data, callback)=> @._POST "#{@.version}/team/#{project}/save/#{team}", data, callback

--- a/test/_issues/bugs/ui.bugs.test.coffee
+++ b/test/_issues/bugs/ui.bugs.test.coffee
@@ -42,13 +42,13 @@ describe '_issues | bugs', ->
       sequence = 0
       promise = api._GET url, (data)->
         (++sequence).assert_Is 2                                # only called after $httpBackend.flush()
-        data.assert_Is ['bsimm', 'samm']
+        data.assert_Is ['bsimm', 'ASVS', 'samm']
       promise.then (data)->
         (++sequence).assert_Is 3                                # called after original promise callback is invoked
-        data.assert_Is ['bsimm', 'samm']
+        data.assert_Is ['bsimm', 'ASVS', 'samm']
       promise.then (data)->
         (++sequence).assert_Is 4                                # confirms multiple calls to 'then' are honored
-        data.assert_Is ['bsimm', 'samm']
+        data.assert_Is ['bsimm', 'ASVS', 'samm']
       (++sequence).assert_Is 1
       $httpBackend.flush()                                      # flush request and trigger callback to first load_Data call
       (++sequence).assert_Is 5                                  # confirms that all 'then' have been called

--- a/test/controllers/project/Project-Scores-Controller.test.coffee
+++ b/test/controllers/project/Project-Scores-Controller.test.coffee
@@ -21,9 +21,9 @@ describe 'controllers | project | Project-Scores', ->
   it 'constructor',->
     using $scope, ->
       @.project.assert_Is 'bsimm'
-      @.data['team-A'].level_1.assert_Is { value: 19.4, percentage: '50%', activities: 39, color: 'green' }
-      @.data['team-A'].level_2.assert_Is { value: 13.4, percentage: '34%', activities: 40, color: 'green' }
-      @.data['team-A'].level_3.assert_Is { value: 4.8 , percentage: '15%', activities: 33, color: 'red'   }
+      @.data['team-A'].level_1.assert_Is { value: 25, percentage: '64%', activities: 39, color: 'green' }
+      @.data['team-A'].level_2.assert_Is { value: 23, percentage: '57%', activities: 40, color: 'green' }
+      @.data['team-A'].level_3.assert_Is { value: 8 , percentage: '24%', activities: 33, color: 'orange'}
        
   it '$scope.get_Style', ->
     $scope.get_Style().assert_Is 'green'

--- a/test/controllers/team/Table-Controller.test.coffee
+++ b/test/controllers/team/Table-Controller.test.coffee
@@ -20,7 +20,7 @@ describe 'controllers | Table-Controller', ->
   it 'check $scope values', ->
     $scope.data.keys().assert_Is [ 'metadata', 'activities' ]
     $scope.rows.size().assert_Is 39
-    $scope.score      .assert_Is '50%'
+    $scope.score      .assert_Is '64%'
     $scope.show       .assert_Is_True()
 
 

--- a/test/controllers/team/Team-Admin-Controller.test.coffee
+++ b/test/controllers/team/Team-Admin-Controller.test.coffee
@@ -1,6 +1,7 @@
 describe 'controllers | Team-Delete-Controller', ->
   $scope      = null
   routeParams = null
+  location    = null
   project     = 'bsimm'
   team        = 'team-A'  
   
@@ -8,11 +9,12 @@ describe 'controllers | Team-Delete-Controller', ->
     module('MM_Graph')
 
   beforeEach ->
-    inject ($controller, $rootScope, $httpBackend, $routeParams)->
+    inject ($controller, $rootScope, $httpBackend, $routeParams, $location)->
       $scope      = $rootScope.$new()
+      location = $location
       $routeParams.project = project
       $routeParams.team    = team
-      #$controller('TeamDataController', { $scope: $scope })
+      #$controller('TeamDataController', { $scope: $scope, $location: $location })
 
       $controller('TeamAdminController', { $scope: $scope })
       $httpBackend.flush()
@@ -21,16 +23,28 @@ describe 'controllers | Team-Delete-Controller', ->
     using $scope, ->
       (typeof @.delete_Team).assert_Is 'function'
       @.delete_Button_Message.assert_Is 'Delete team team-A'
+      @.rename_Button_Message.assert_Is 'Rename team team-A'
 
   it '$scope.delete_Team', ->
     using $scope, ->
-      @.status.assert_Is ""
+      @.deleteStatus.assert_Is ""
       @.delete_Team()
-      @.status.assert_Is 'deleting team'
+      @.deleteStatus.assert_Is 'deleting team'
       inject ($httpBackend)->
         $httpBackend.expectGET("/api/v1/team/#{project}/delete/#{team}").respond { status: 'deleted'}
         $httpBackend.flush()
-      @.status.assert_Is { status: 'deleted'}
+      @.deleteStatus.assert_Is { status: 'deleted'}
+
+  it '$scope.rename_Team success', ->
+    using $scope, ->
+      @.project = project
+      @.team = team
+      newTeamName = 'super-team'
+      @.rename_Team(newTeamName)
+      inject ($httpBackend)->
+        $httpBackend.expectGET("/api/v1/team/#{project}/rename/#{team}/#{newTeamName}").respond true
+        $httpBackend.flush()
+      @.renameStatus.contains 'renamed'
 
 
 

--- a/test/controllers/team/Team-Admin-Controller.test.coffee
+++ b/test/controllers/team/Team-Admin-Controller.test.coffee
@@ -1,6 +1,5 @@
-describe 'controllers | Team-Delete-Controller', ->
+describe 'controllers | Team-Admin-Controller', ->
   $scope      = null
-  routeParams = null
   location    = null
   project     = 'bsimm'
   team        = 'team-A'  
@@ -14,8 +13,6 @@ describe 'controllers | Team-Delete-Controller', ->
       location = $location
       $routeParams.project = project
       $routeParams.team    = team
-      #$controller('TeamDataController', { $scope: $scope, $location: $location })
-
       $controller('TeamAdminController', { $scope: $scope })
       $httpBackend.flush()
 
@@ -40,11 +37,28 @@ describe 'controllers | Team-Delete-Controller', ->
       @.project = project
       @.team = team
       newTeamName = 'super-team'
+      location.path("/view/ASVS/#{team}/admin")
+      @.$apply()
       @.rename_Team(newTeamName)
       inject ($httpBackend)->
         $httpBackend.expectGET("/api/v1/team/#{project}/rename/#{team}/#{newTeamName}").respond true
         $httpBackend.flush()
       @.renameStatus.contains 'renamed'
+      location.path().assert_Is "/view/ASVS/#{newTeamName}/admin"
+
+  it '$scope.rename_Team fail', ->
+    using $scope, ->
+      @.project = project
+      @.team = team
+      newTeamName = 'super-team'
+      originalLocation = "/view/ASVS/#{team}/admin"
+      location.path(originalLocation)
+      @.rename_Team(newTeamName)
+      inject ($httpBackend)->
+        $httpBackend.expectGET("/api/v1/team/#{project}/rename/#{team}/#{newTeamName}").respond false
+        $httpBackend.flush()
+      @.renameStatus.contains 'failed'
+      location.path().assert_Is originalLocation
 
 
 

--- a/test/directives/team-table.directive.test.coffee
+++ b/test/directives/team-table.directive.test.coffee
@@ -6,7 +6,9 @@ describe 'directive | team-table', ->
   html    = null
 
   beforeEach ()->
-    module('MM_Graph')
+    module('MM_Graph', ($provide) ->
+      $provide.constant 'team_Mappings', load_Data: ->
+    )
 
   beforeEach ->
     inject ($rootScope, $controller, $compile)->
@@ -15,6 +17,7 @@ describe 'directive | team-table', ->
       $compile(element)($scope)
       $scope.$apply()
       html     = element.outerHTML
+
 
   it 'check columns names', ->
     table_Headers = (a.innerText for a in $(html).find('th'))

--- a/test/services/API.test.coffee
+++ b/test/services/API.test.coffee
@@ -76,9 +76,9 @@ describe 'services | API', ->
   it 'data_Radar_Team'       , -> call_API "data_Radar_Team"        , [project, team], (data)-> data.axes.first().value.assert_Is 0.4091
   it 'data_Radar_Fields'     , -> call_API "data_Radar_Fields"      , [project      ], (data)-> data.axes.first().assert_Is { axis: 'SM', name: 'Strategy & Metrics', key: 'SM', xOffset: 20, value: 0 , size: 11}
   it 'project_Get'           , -> call_API "project_Get"            , [project      ], (data)-> data.assert_Contains ['level-1', 'level-2','level-3']
-  it 'project_List'          , -> call_API "project_List"           , [             ], (data)-> data.assert_Is ['bsimm','samm']
+  it 'project_List'          , -> call_API "project_List"           , [             ], (data)-> data.assert_Is ['bsimm', 'ASVS', 'samm']
   it 'project_Schema_Details', -> call_API "project_Schema_Details" , [project      ], (data)-> data.activities['SM.1.1'].keys().assert_Is [ 'description', 'resources', 'objective', 'proof' ]
-  it 'project_Scores'        , -> call_API "project_Scores"         , [project      ], (data)-> data['team-A']['level_1'].assert_Is { value: 19.4, percentage: '50%', activities: 39 }
+  it 'project_Scores'        , -> call_API "project_Scores"         , [project      ], (data)-> data['team-A']['level_1'].assert_Is { value: 25, percentage: '64%', activities: 39 }
   it 'routes'                , -> call_API "routes"                 , [             ], (data)-> data.raw.assert_Contains ['/ping']
   it 'teams_Proofs'          , -> call_API "teams_Proofs"           , [project      ], (data)-> data['SM.1.1']['level-1'].assert_Is { value: 'Yes', proof: '' }
 

--- a/test/views/welcome.page.test.coffee
+++ b/test/views/welcome.page.test.coffee
@@ -16,13 +16,13 @@ describe 'views | welcome.page', ->
         
   it 'pages/view.page.html', ->     
     using view, ->
-      @.$('li').length.assert_Is 2   # this is wrong, there should be list with project values
+      @.$('li').length.assert_Is 3   # this is wrong, there should be list with project values
       @.$('#project').attr('ng-controller').assert_Is 'ProjectsController'
-      scope.projects.assert_Is ['bsimm', 'samm']           
+      scope.projects.assert_Is ['ASVS', 'bsimm', 'samm']
 
   it 'access the scope of the ProjectsController', ->  # todo: find a better way to find this
     using view, ->
       scope_1 = @.scope.$$childHead.$$childHead.$$childHead
       scope_2 = angular.element(angular.element(@.element).find('div')[1]).scope()
-      scope_1.projects.assert_Is ['bsimm', 'samm']
-      scope_2.projects.assert_Is ['bsimm', 'samm']
+      scope_1.projects.assert_Is ['ASVS', 'bsimm', 'samm']
+      scope_2.projects.assert_Is ['ASVS', 'bsimm', 'samm']

--- a/views/pages/team/admin.pug
+++ b/views/pages/team/admin.pug
@@ -3,11 +3,22 @@ div(ng-controller='TeamAdminController')
     .row.fullWidth
         .small-2.columns
             label.right.inline
-                b Delete Team:
+                b New team name:
+        .small-3.columns
+            input(type='text' ng-model='newTeamName' placeholder='New team name')
         .small-2.columns
-            a.button.postfix#delete-button(ng-click='delete_Team()') {{delete_Button_Message}}
-        .small-2.columns
+            a.button.postfix#rename-button(ng-click='rename_Team(newTeamName)') {{rename_Button_Message}}
         .small-1.columns
-            .center.label.round#status-label(ng-class='messageClass') {{status}}
+            .center.label.round#teamname-label(ng-class='messageClass' ng-if='!!renameStatus') {{renameStatus}}
+        .small-4.columns
+
+    .row.fullWidth
+        .small-2.columns
+            label.right.inline
+                b Delete Team:
+        .small-3.columns
+            a.button.postfix#delete-button(ng-click='delete_Team()') {{delete_Button_Message}}
+        .small-1.columns
+            .center.label.round#status-label(ng-class='messageClass' ng-if='!!deleteStats') {{deleteStatus}}
         .small-4.columns
 


### PR DESCRIPTION
This solves https://github.com/OWASP/Maturity-Models/issues/161.

I've also fixed all unit tests so everything is now green (some broke because of ASVS, and some were broken before ASVS). The unit test fixes is in a separate commit, so it's easier to review the "rename team" separately. 